### PR TITLE
Master jhou lab2

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ There are multiple ways to install:
     - In cmd window, cd to main directory, making sure the venv is active, then enter one of the following, based on whether you are on Windows or Mac:
     -     pyinstaller neurodemo_windows.spec
     -     pyinstaller neurodemo_mac.spec
-    - Executable neurodemo.exe will be created in the dist directory. You can run it by double-clicking it.
+    - This will create an executable file in the "dist" directory. You can run it by double-clicking it.
     - It does NOT need any other files, and you can give this file to others and they should be able to run it without
     - having to install anything.
     - 

--- a/README.md
+++ b/README.md
@@ -71,12 +71,19 @@ There are multiple ways to install:
 3. Creating a standalone Windows or Mac executable file to distribute to others.
 
     - Git clone the repository. 
-    - Create a python venv in the main directory.
+    - Create and activate a python venv in the main directory and install all dependencies.
     - In cmd window, install pyinstaller as follows:
     -     pip install pyinstaller
-    - In cmd window, cd to main directory, activate the venv, then enter:
-    -     pyinstaller neurodemo.spec
-    - Executable neurodemo.exe will be created in the dist directory. Pyinstaller will also put a bunch of files into the build/neurodemo folder, which can be ignored.
+    - In cmd window, cd to main directory, making sure the venv is active, then enter one of the following, based on whether you are on Windows or Mac:
+    -     pyinstaller neurodemo_windows.spec
+    -     pyinstaller neurodemo_mac.spec
+    - Executable neurodemo.exe will be created in the dist directory. You can run it by double-clicking it.
+    - It does NOT need any other files, and you can give this file to others and they should be able to run it without
+    - having to install anything.
+    - 
+    - The Windows version will show a splash screen while starting up (which takes a few seconds). Unfortunately the
+    - splash screen is not compatible with Mac (which is why it needs a separate .spec file) so you just have to trust it is working
+    - while waiting for it to start up.
 
 
 Running the Demo

--- a/README.md
+++ b/README.md
@@ -77,13 +77,10 @@ There are multiple ways to install:
     - In cmd window, cd to main directory, making sure the venv is active, then enter one of the following, based on whether you are on Windows or Mac:
     -     pyinstaller neurodemo_windows.spec
     -     pyinstaller neurodemo_mac.spec
-    - This will create an executable file in the "dist" directory. You can run it by double-clicking it.
-    - It does NOT need any other files, and you can give this file to others and they should be able to run it without
-    - having to install anything.
+    - This will create a stand-alone executable file in the "dist" directory. You can run it by double-clicking it.
     - 
-    - The Windows version will show a splash screen while starting up (which takes a few seconds). Unfortunately the
-    - splash screen is not compatible with Mac (which is why it needs a separate .spec file) so you just have to trust it is working
-    - while waiting for it to start up.
+    - The Windows version shows a splash screen while starting up (which takes several seconds). Unfortunately the
+    - splash screen is not compatible with Mac (which is why it needs a separate .spec file).
 
 
 Running the Demo

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ There are multiple ways to install:
     - In the main directory, under the windows cmd terminal, run win_install.bat.
     - Create a shortcut on the desktop to the file win_start_demo.bat, and set the "window" to minimized. 
         Clicking on the shortcut should start the program. 
-    - There is no working way to make an exe file at the moment - the .spec file are getting close but not working yet (missing a windows dll).
     
     b. macOS
     - Git clone the repository.
@@ -68,19 +67,17 @@ There are multiple ways to install:
     -  type "python demo.py" to run the program. 
     - To make an installable file (dmg), run the shell script that is appropriate for the processor: make_M1_dmg.sh or make_x86_64_dmg.sh. The resulting dmg file will be in the folder dist/demo_(architecture).dmg. You can then install the app as you would with any other dmg file.  
 
-3. Creating a standalone Windows or Mac executable file to distribute to others.
+3. Create a single standalone executable file to distribute to others.
 
     - Git clone the repository. 
-    - Create and activate a python venv in the main directory and install all dependencies.
-    - In cmd window, install pyinstaller as follows:
+    - Create *and activate* a python virtual environment (venv) in the main repository directory and install all dependencies. Also, install pyinstaller:
     -     pip install pyinstaller
-    - In cmd window, cd to main directory, making sure the venv is active, then enter one of the following, based on whether you are on Windows or Mac:
+    - At the command line, cd to main repository directory, making sure the venv is active, then enter one of the following, based on whether you are on Windows or Mac:
     -     pyinstaller neurodemo_windows.spec
     -     pyinstaller neurodemo_mac.spec
-    - This will create a stand-alone executable file in the "dist" directory. You can run it by double-clicking it.
+    - This will create a subfolder "dist" containing a stand-alone executable that you can run by double-clicking. It will also create a subfolder "build" with intermediate files that you can generally ignore.
     - 
-    - The Windows version shows a splash screen while starting up (which takes several seconds). Unfortunately the
-    - splash screen is not compatible with Mac (which is why it needs a separate .spec file).
+    - The Windows executable should take 4-5 seconds to launch, during which it shows a splash screen. The splash screen feature is not compatible with Mac. The Mac version also might take curiously long to launch (almost 30 seconds). Not sure why, but it seems fine after that. 
 
 
 Running the Demo

--- a/neurodemo/clampparam.py
+++ b/neurodemo/clampparam.py
@@ -369,7 +369,7 @@ class ClampParameter(pt.parameterTypes.SimpleParameter):
         self.plot_win.remove_plot(key)
 
     def get_oldest_result(self):
-        # Find index of buffer having the lowest timestamp
+        # Find index of result_buffer having the lowest timestamp
         earliest_t = -1
         earliest_i = -1
         for i, r in enumerate(self.result_buffer):

--- a/neurodemo/clampparam.py
+++ b/neurodemo/clampparam.py
@@ -369,16 +369,19 @@ class ClampParameter(pt.parameterTypes.SimpleParameter):
         self.plot_win.remove_plot(key)
 
     def get_oldest_result(self):
-        earliest = -1
+        earliest_t = -1
+        earliest_i = -1
         for i, r in enumerate(self.result_buffer):
             t = r["t"][0]
-            if earliest == -1:
-                earliest = t
+            if earliest_t == -1:
+                earliest_t = t
+                earliest_i = i
             else:
-                if t < earliest:
-                    earliest = t
-        if i >= 0:
-            return self.result_buffer.pop(i)
+                if t < earliest_t:
+                    earliest_t = t
+                    earliest_i = i
+        if earliest_i >= 0:
+            return self.result_buffer.pop(int(earliest_i))
         else:
             raise ValueError("Cannot find oldest result in queue")
 

--- a/neurodemo/clampparam.py
+++ b/neurodemo/clampparam.py
@@ -369,6 +369,7 @@ class ClampParameter(pt.parameterTypes.SimpleParameter):
         self.plot_win.remove_plot(key)
 
     def get_oldest_result(self):
+        # Find index of buffer having the lowest timestamp
         earliest_t = -1
         earliest_i = -1
         for i, r in enumerate(self.result_buffer):

--- a/neurodemo/main_window.py
+++ b/neurodemo/main_window.py
@@ -5,6 +5,7 @@ Luke Campagnola 2015
 """
 
 from __future__ import annotations
+import typing
 
 # make sure we get the right pyqtgraph.
 from dataclasses import dataclass
@@ -133,7 +134,7 @@ class DemoWindow(qt.QWidget):
         self.clamp_param.plots_changed.connect(self.plots_changed)
         self.clamp_param.mode_changed.connect(self.mode_changed)
 
-        self.channel_plots = {}
+        self.channel_plots: typing.Dict[str, ScrollingPlot] = {}
         
         self.channel_params = [
             ChannelParameter(self.leak),
@@ -191,8 +192,11 @@ class DemoWindow(qt.QWidget):
 
         self.clamp_param['Plot Current'] = True
         self.clamp_param['Plot Command'] = True
-        self.plot_splitter.setSizes([300, 500, 200])
-        
+
+        # Set default heights of neuronview, membrane voltage, and other initial scrolling graphs.
+        self.plot_splitter.setSizes([300, 500] + [200] * (len(self.plot_splitter.sizes()) - 2))
+
+        # Any additional plots must be added after setting default heights
         self.pause_shortcut = qt.QShortcut(qt.QKeySequence('Space'), self)
         self.pause_shortcut.activated.connect(self.pause)
         self.slow_shortcut = qt.QShortcut(qt.QKeySequence('-'), self)
@@ -325,7 +329,7 @@ class DemoWindow(qt.QWidget):
         r = len(sizes) / (len(sizes)+1)
         sizes = [int(s * r) for s in sizes] + [int(size)]
         self.plot_splitter.setSizes(sizes)
-        
+
         # Ask sequence plotter to update as well
         self.clamp_param.add_plot(key, label)
 

--- a/neurodemo/main_window.py
+++ b/neurodemo/main_window.py
@@ -411,14 +411,12 @@ class DemoWindow(qt.QWidget):
 
     def set_scrolling_plot_duration(self, val):
         self.scrolling_plot_duration = val
-        # Set x-axis limits for membrane voltage plot, so that user can't zoom
-        # out farther than the max plot time. This reduces chance of accidentally
-        # "losing" the plot trace.
+        # Update x-axis limits for membrane voltage plot, so we don't "lose" the traces by accident.
         self.vm_plot.setLimits(xMin=-val)
         for k in self.channel_plots.keys():
             self.channel_plots[k].set_duration(val)
-            # Set new range, and also set x-limits on remaining scrolling plots.
-            # ScrollingPLot.setLimits() and .setXRange() are wrapped from ViewBox
+            # Update range and x-limits on all other ScrollingPlot objects
+            # Note: ScrollingPLot.setLimits() and .setXRange() are wrapped from pyqtgraph ViewBox
             self.channel_plots[k].setLimits(xMin=-val, xMax=0)
             self.channel_plots[k].setXRange(-val, 0)
 

--- a/neurodemo/main_window.py
+++ b/neurodemo/main_window.py
@@ -190,6 +190,7 @@ class DemoWindow(qt.QWidget):
         # self.start()  # if autostart desired
 
         self.clamp_param['Plot Current'] = True
+        self.clamp_param['Plot Command'] = True
         self.plot_splitter.setSizes([300, 500, 200])
         
         self.pause_shortcut = qt.QShortcut(qt.QKeySequence('Space'), self)
@@ -406,7 +407,10 @@ class DemoWindow(qt.QWidget):
         self.vm_plot.setLimits(xMin=-val)
         for k in self.channel_plots.keys():
             self.channel_plots[k].set_duration(val)
+            # Set new range, and also set limits so user can't scroll out too far.
+            # ScrollingPLot.setLimits() and .setXRange() are wrapped from ViewBox
             self.channel_plots[k].setLimits(xMin=-val, xMax=0)
+            self.channel_plots[k].setXRange(-val, 0)
 
     def pause(self):
         self.params['Run'] = not self.params['Run']

--- a/neurodemo/main_window.py
+++ b/neurodemo/main_window.py
@@ -4,6 +4,7 @@ NeuroDemo - Physiological neuron sandbox for educational purposes
 Luke Campagnola 2015
 """
 
+# Starting to add a few type hints. This is very preliminary.
 from __future__ import annotations
 import typing
 
@@ -176,6 +177,8 @@ class DemoWindow(qt.QWidget):
             dict(name='Ion Channels', type='group', children=self.channel_params),
         ])
 
+        # Now that add_plot() sets x-axis limits, it must be called after defining self.params,
+        # which contains info about the plot duration.
         self.vm_plot = self.add_plot('soma.V', 'Membrane Potential', 'V')
         self.splitter.setSizes([300, 300, 800])
 
@@ -408,10 +411,13 @@ class DemoWindow(qt.QWidget):
 
     def set_scrolling_plot_duration(self, val):
         self.scrolling_plot_duration = val
+        # Set x-axis limits for membrane voltage plot, so that user can't zoom
+        # out farther than the max plot time. This reduces chance of accidentally
+        # "losing" the plot trace.
         self.vm_plot.setLimits(xMin=-val)
         for k in self.channel_plots.keys():
             self.channel_plots[k].set_duration(val)
-            # Set new range, and also set limits so user can't scroll out too far.
+            # Set new range, and also set x-limits on remaining scrolling plots.
             # ScrollingPLot.setLimits() and .setXRange() are wrapped from ViewBox
             self.channel_plots[k].setLimits(xMin=-val, xMax=0)
             self.channel_plots[k].setXRange(-val, 0)

--- a/neurodemo/main_window.py
+++ b/neurodemo/main_window.py
@@ -353,7 +353,7 @@ class DemoWindow(qt.QWidget):
         if self.running():
             return
         if len(items) == 0:
-            # Can happen if mouse is dragged past limit
+            # Can happen if mouse is dragged past valid time limit
             return
         item = items[0]
         widget = item.getViewWidget()
@@ -361,7 +361,7 @@ class DemoWindow(qt.QWidget):
         localPos = widget.mapFromGlobal(globalPos)
         scenePos = item.mapFromDevice(localPos)
         if not hasattr(item, 'vb'):
-            # Can happen if mouse dragged past limit
+            # Can happen if mouse dragged past valid time limit
             return
         viewPos = item.vb.mapSceneToView(scenePos)
         self.set_hover_time(viewPos.x())


### PR DESCRIPTION
Hey Luke and Paul: I just noticed (and fixed) a bug in which get_oldest_result() in clampparam.py returns the newest result_buffer, instead of oldest. Because of this, pulses delivered immediately after starting a run might be missing initial samples. This is more noticeable than before, due to my adding the auto-start feature, and is especially noticeable if one clicks "Pulse Sequence" while stopped, as the overlaid traces are all offset leftward due to missing samples.

I added separate .spec files for Windows and Mac, since the splash screen stuff isn't compatible with Mac, and updated the README.md instructions accordingly.  Strangely, the Mac executable takes almost 30 seconds to launch on my machine (an M1 mac mini), versus 4-5 seconds for the Windows version (running on similarly aged hardware).

Incidentally, I tried your "make_M1_dmg.sh" shell script to see if it would make a faster-launching app, and got an Import error about halfway through. I didn't see an obvious way to fix it, but also haven't tried very hard yet. I'm hoping you can check it. In general, there seemed to be a lot of useful *.sh scripts for Windows, Mac, and Linux, but I had various problems when I tried using them.

I added x-axis limits to ScrollingPlots so they can't be accidentally zoomed out farther in time than the max available data. This choice is aesthetic rather than functional, but I did it because it felt disconcerting to see beyond the temporal "endpoints" into empty space. I also found I tended to accidentally "lose" the traces by moving out of the valid timeline, so this no longer happens.

The "command" pulses are now plotted by default when first launched. I felt this helps beginners to see what is being done to the model neuron. I had to modify the line of code that sets the initial plot window heights - it can now accommodate an arbitrary number of initial plots.

Lastly, I made a half-hearted attempt to add type hints, but didn't get very far.

Hope this all makes sense!

- Tom